### PR TITLE
fix for bug when clicking on a link past the first page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "search-enhancer-for-google",
-    "version": "3.15.0",
+    "version": "3.16.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "search-enhancer-for-google",
-            "version": "3.15.0",
+            "version": "3.16.0",
             "dependencies": {
                 "@loftyshaky/shared": "2.6.0",
                 "@simonwep/pickr": "^1.9.1",
@@ -2718,18 +2718,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/@types/eslint": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.1.tgz",
-            "integrity": "sha512-18PLWRzhy9glDQp3+wOgfLYRWlhgX0azxgJ63rdpoUHyrC9z0f5CkFburjQx4uD7ZCruw85ZtMt6K+L+R8fLJQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/estree": "*",
-                "@types/json-schema": "*"
             }
         },
         "node_modules/@types/estree": {

--- a/src/ts/content_script/content_script.ts
+++ b/src/ts/content_script/content_script.ts
@@ -1,8 +1,9 @@
 import { init_shared } from '@loftyshaky/shared/shared';
 import 'shared/internal';
-import { init, s_location } from 'content_script/internal';
+import { init, s_google_settings, s_location } from 'content_script/internal';
 
 const init_all = () => {
+    s_google_settings.GoogleSettings.get_settings();
     s_location.Location.set_current_location();
 
     init_shared();

--- a/src/ts/content_script/google_settings/scripts/google_settings.ts
+++ b/src/ts/content_script/google_settings/scripts/google_settings.ts
@@ -1,0 +1,19 @@
+class Class {
+    private static instance: Class;
+
+    public static get_instance(): Class {
+        return this.instance || (this.instance = new this());
+    }
+
+    // eslint-disable-next-line no-useless-constructor, no-empty-function
+    private constructor() {}
+
+    public open_results_in_new_window: boolean = false;
+
+    public get_settings = (): void =>
+        err(() => {
+            this.open_results_in_new_window = n(s('[name="newwindow"]')); // true, if "Results in a new window" option in Google search settings is on
+        }, 'seg_1248');
+}
+
+export const GoogleSettings = Class.get_instance();

--- a/src/ts/content_script/google_settings/scripts/index.ts
+++ b/src/ts/content_script/google_settings/scripts/index.ts
@@ -1,0 +1,1 @@
+export * from 'content_script/google_settings/scripts/google_settings';

--- a/src/ts/content_script/infinite_scroll/scripts/iframe.ts
+++ b/src/ts/content_script/infinite_scroll/scripts/iframe.ts
@@ -174,6 +174,7 @@ class Class {
                                     this.last_iframe.contentDocument;
 
                                 if (n(iframe_doc)) {
+                                    this.retarget_iframe_links({ iframe_doc });
                                     x.css(
                                         'font_face',
                                         iframe_doc.head,
@@ -198,14 +199,18 @@ class Class {
         | Document
         | undefined =>
         err(() => {
-            if (n(this.last_iframe)) {
-                const iframe_doc: Document | null = n(cur_iframe_i)
-                    ? this.iframes[cur_iframe_i].contentDocument
-                    : this.last_iframe.contentDocument;
+            const cur_iframe: HTMLIFrameElement | undefined = n(cur_iframe_i)
+                ? this.iframes[cur_iframe_i]
+                : this.last_iframe;
 
-                if (n(iframe_doc)) {
-                    return iframe_doc;
-                }
+            if (!n(cur_iframe)) {
+                return undefined;
+            }
+
+            const iframe_doc: Document | null = cur_iframe.contentDocument;
+
+            if (n(iframe_doc)) {
+                return iframe_doc;
             }
 
             return undefined;
@@ -251,8 +256,12 @@ class Class {
     private resize_iframe = ({ cur_iframe_i }: { cur_iframe_i: number }): Promise<void> =>
         err_async(async () => {
             const scroll_top = document.documentElement.scrollTop;
-            const cur_iframe: HTMLIFrameElement = this.iframes[cur_iframe_i];
+            const cur_iframe: HTMLIFrameElement | undefined = this.iframes[cur_iframe_i];
             const iframe_doc: Document | undefined = this.get_iframe_doc({ cur_iframe_i });
+
+            if (!n(cur_iframe)) {
+                return;
+            }
 
             await globalThis.requestAnimationFrame(
                 async (): Promise<void> =>
@@ -323,6 +332,56 @@ class Class {
                 ? '#rso'
                 : '#search';
         }, 'seg_1237');
+
+    private retarget_iframe_links = ({ iframe_doc }: { iframe_doc: Document }): void =>
+        err(() => {
+            const retargeted_attr = 'data-seg-link-retargeted';
+
+            if (iframe_doc.documentElement.hasAttribute(retargeted_attr)) {
+                return;
+            }
+
+            iframe_doc.documentElement.setAttribute(retargeted_attr, 'true');
+
+            const links = iframe_doc.querySelectorAll('a');
+
+            if (n(links)) {
+                links.forEach((link: HTMLAnchorElement): void => {
+                    link.target = '_top';
+                });
+            }
+
+            iframe_doc.addEventListener(
+                'click',
+                (event: MouseEvent): void => {
+                    if (event.defaultPrevented || event.button !== 0) {
+                        return;
+                    }
+
+                    const target = event.target as HTMLElement | null;
+                    const link = target ? x.closest(target, 'a') : undefined;
+
+                    if (!n(link)) {
+                        return;
+                    }
+
+                    const { href } = link as HTMLAnchorElement;
+
+                    if (!href) {
+                        return;
+                    }
+
+                    event.preventDefault();
+
+                    if (globalThis.top) {
+                        globalThis.top.location.href = href;
+                    } else {
+                        globalThis.location.href = href;
+                    }
+                },
+                true,
+            );
+        }, 'seg_1240');
 }
 
 export const Iframe = Class.get_instance();

--- a/src/ts/content_script/infinite_scroll/scripts/iframe.ts
+++ b/src/ts/content_script/infinite_scroll/scripts/iframe.ts
@@ -6,6 +6,7 @@ import {
     d_side_panel,
     s_actions,
     s_el_parser,
+    s_google_settings,
     s_location,
     s_roots,
     s_theme,
@@ -333,9 +334,21 @@ class Class {
                 : '#search';
         }, 'seg_1237');
 
-    private retarget_iframe_links = ({ iframe_doc }: { iframe_doc: Document }): void =>
+    private retarget_iframe_links = ({
+        iframe_doc,
+    }: {
+        iframe_doc: Document;
+    }): void => // Prevent search result links on the second and following pages opening in an iframe when "Results in a new window" option in Google search settings is off.
         err(() => {
-            const retargeted_attr = 'data-seg-link-retargeted';
+            if (
+                s_google_settings.GoogleSettings.open_results_in_new_window &&
+                !s_location.Location.is_books_page
+            ) {
+                // If "Results in a new window" option in Google search settings is on, let link open in a new tab. Always open results in "Books" in current tab.
+                return;
+            }
+
+            const retargeted_attr: string = new s_suffix.Suffix('data-seg-link-retargeted').result;
 
             if (iframe_doc.documentElement.hasAttribute(retargeted_attr)) {
                 return;
@@ -343,45 +356,48 @@ class Class {
 
             iframe_doc.documentElement.setAttribute(retargeted_attr, 'true');
 
-            const links = iframe_doc.querySelectorAll('a');
+            const links = sab<HTMLAnchorElement>(iframe_doc, 'a');
 
             if (n(links)) {
-                links.forEach((link: HTMLAnchorElement): void => {
-                    link.target = '_top';
-                });
+                links.forEach((link: HTMLAnchorElement): void =>
+                    err(() => {
+                        link.target = '_top';
+                    }, 'seg_1250'),
+                );
             }
 
             iframe_doc.addEventListener(
                 'click',
-                (event: MouseEvent): void => {
-                    if (event.defaultPrevented || event.button !== 0) {
-                        return;
-                    }
+                (e: MouseEvent): void =>
+                    err(() => {
+                        if (e.defaultPrevented || e.button !== 0) {
+                            return;
+                        }
 
-                    const target = event.target as HTMLElement | null;
-                    const link = target ? x.closest(target, 'a') : undefined;
+                        const target = e.target as HTMLElement | null;
+                        const link = n(target) ? x.closest(target, 'a') : undefined;
 
-                    if (!n(link)) {
-                        return;
-                    }
+                        if (!n(link)) {
+                            return;
+                        }
 
-                    const { href } = link as HTMLAnchorElement;
+                        const { href } = link as HTMLAnchorElement;
 
-                    if (!href) {
-                        return;
-                    }
+                        if (!href) {
+                            return;
+                        }
 
-                    event.preventDefault();
+                        e.preventDefault();
 
-                    if (globalThis.top) {
-                        globalThis.top.location.href = href;
-                    } else {
-                        globalThis.location.href = href;
-                    }
-                },
+                        if (globalThis.top) {
+                            globalThis.top.location.href = href;
+                        } else {
+                            globalThis.location.href = href;
+                        }
+                    }, 'seg_1251'),
                 true,
             );
-        }, 'seg_1240');
+        }, 'seg_1249');
 }
 
 export const Iframe = Class.get_instance();

--- a/src/ts/content_script/internal.ts
+++ b/src/ts/content_script/internal.ts
@@ -18,6 +18,7 @@ export * as d_side_panel from 'content_script/side_panel/data';
 export * as s_actions from 'content_script/actions/scripts';
 export * as s_ai_block from 'content_script/ai_block/scripts';
 export * as s_el_parser from 'content_script/el_parser/scripts';
+export * as s_google_settings from 'content_script/google_settings/scripts';
 export * as s_icons from 'content_script/icons/scripts';
 export * as s_img_action_bar from 'content_script/img_action_bar/scripts';
 export * as s_infinite_scroll from 'content_script/infinite_scroll/scripts';


### PR DESCRIPTION
## fixes

1. Add a guard in the get_iframe_doc function
2. created retarget_iframe_links function, to open in a new window, 
I used "seg_1240" string, I checked to make sure no other function was using the string.


## retarget_iframe_links function explanation

first checks if the attribute is applied and runs only once; returns if already set.

```
const retargeted_attr = 'data-seg-link-retargeted';

if (iframe_doc.documentElement.hasAttribute(retargeted_attr)) {
     return;
}

iframe_doc.documentElement.setAttribute(retargeted_attr, 'true');
```

Finds all <a> elements and sets link.target = '_top'.w
Setting target='_top' forces the browser to to open the linked page in the full body of the current browser window.
```
const links = iframe_doc.querySelectorAll('a');
 if (n(links)) {
       links.forEach((link: HTMLAnchorElement): void => {
       link.target = '_top';
     });
}
```

Lastly the event listener, while not necessary for it to work, it is just extra protection just in case any JS click listener happens in the page. 

`iframe_doc.addEventListener(`



Anyways I really enjoyed your extension and it is very useful for me. I am just happy help you out.